### PR TITLE
feat: add configurable formUrl

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ export const useFormspark = (args: Args) => {
 
   const submit = (payload: SubmitPayload) => {
     return new Promise((resolve, reject) => {
-      const url = `${BASE_URL}/${args.formId}`;
+      const url = `${args.formUrl ? args.formUrl : BASE_URL}/${args.formId}`;
       const method = 'POST';
       const headers = {
         Accept: 'application/json',

--- a/src/types/use-formspark.ts
+++ b/src/types/use-formspark.ts
@@ -1,5 +1,6 @@
 export type Args = {
   formId: string;
+  formUrl?: string;
 };
 
 export type SubmitPayload = Record<string, unknown>;


### PR DESCRIPTION
I'd prefer to use your formspark hook, but the BASE_URL doesn't work for next.js requests. You mentioned to change to "https://api.formspark.io/" which is not configurable yet. So I added it. @botre 